### PR TITLE
Ignore missing samplesperpixel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target/
+
+# IntelliJ
+.idea
+*.iml

--- a/src/main/java/mil/nga/tiff/FileDirectory.java
+++ b/src/main/java/mil/nga/tiff/FileDirectory.java
@@ -480,8 +480,13 @@ public class FileDirectory {
 	 * 
 	 * @return samples per pixel
 	 */
-	public Integer getSamplesPerPixel() {
-		return getIntegerEntryValue(FieldTagType.SamplesPerPixel);
+	public int getSamplesPerPixel() {
+		Integer samplesPerPixel = getIntegerEntryValue(FieldTagType.SamplesPerPixel);
+		if (samplesPerPixel != null)
+			return samplesPerPixel;
+
+		// if SamplesPerPixel tag is missing, use length of BitsPerSample list
+		return getBitsPerSample().size();
 	}
 
 	/**

--- a/src/main/java/mil/nga/tiff/Rasters.java
+++ b/src/main/java/mil/nga/tiff/Rasters.java
@@ -145,6 +145,13 @@ public class Rasters {
 				new Number[samplesPerPixel][width * height]);
 	}
 
+	public static List<Integer> makeBitsPerSampleList(int samplesPerPixel, int bitsPerSample) {
+		List<Integer> bitsPerSampleList = new ArrayList<Integer>();
+		for (int i = 0; i < samplesPerPixel; ++i)
+			bitsPerSampleList.add(bitsPerSample);
+		return bitsPerSampleList;
+	}
+
 	/**
 	 * Constructor
 	 * 
@@ -155,11 +162,11 @@ public class Rasters {
 	 * @param samplesPerPixel
 	 *            samples per pixel
 	 * @param bitsPerSample
-	 *            single sample bits per sample
+	 *            bits per sample for all samples of a pixel
 	 */
 	public Rasters(int width, int height, int samplesPerPixel, int bitsPerSample) {
-		this(width, height, samplesPerPixel, new ArrayList<Integer>(
-				Arrays.asList(bitsPerSample)));
+		this(width, height, samplesPerPixel,
+				makeBitsPerSampleList(samplesPerPixel, bitsPerSample));
 	}
 
 	/**
@@ -593,5 +600,4 @@ public class Rasters {
 
 		return rowsPerStrip;
 	}
-
 }

--- a/src/test/java/mil/nga/tiff/TiffTestUtils.java
+++ b/src/test/java/mil/nga/tiff/TiffTestUtils.java
@@ -93,7 +93,7 @@ public class TiffTestUtils {
 		TestCase.assertEquals(fileDirectory.getImageWidth(), rasters.getWidth());
 		TestCase.assertEquals(fileDirectory.getImageHeight(),
 				rasters.getHeight());
-		TestCase.assertEquals(fileDirectory.getSamplesPerPixel().intValue(),
+		TestCase.assertEquals(fileDirectory.getSamplesPerPixel(),
 				rasters.getSamplesPerPixel());
 		TestCase.assertEquals(fileDirectory.getBitsPerSample().size(), rasters
 				.getBitsPerSample().size());


### PR DESCRIPTION
If a Tiff is created with python, SamplesPerPixel seems to be missing if the value is 1. This is a workaround to read the Tiff anyway.