### PR TITLE
uses int instead of Number for image and tile sizes

### DIFF
--- a/src/main/java/mil/nga/tiff/FileDirectory.java
+++ b/src/main/java/mil/nga/tiff/FileDirectory.java
@@ -113,7 +113,7 @@ public class FileDirectory {
 		setCache(cacheData);
 
 		// Determine if tiled
-		tiled = getRowsPerStrip() == null;
+		tiled = getEntryValue(FieldTagType.RowsPerStrip) == null;
 
 		// Determine and validate the planar configuration
 		Integer pc = getPlanarConfiguration();
@@ -294,8 +294,8 @@ public class FileDirectory {
 	 * 
 	 * @return image width
 	 */
-	public Number getImageWidth() {
-		return getNumberEntryValue(FieldTagType.ImageWidth);
+	public int getImageWidth() {
+		return getNumberEntryValue(FieldTagType.ImageWidth).intValue();
 	}
 
 	/**
@@ -323,8 +323,8 @@ public class FileDirectory {
 	 * 
 	 * @return image height
 	 */
-	public Number getImageHeight() {
-		return getNumberEntryValue(FieldTagType.ImageLength);
+	public int getImageHeight() {
+		return getNumberEntryValue(FieldTagType.ImageLength).intValue();
 	}
 
 	/**
@@ -507,8 +507,8 @@ public class FileDirectory {
 	 * 
 	 * @return rows per strip
 	 */
-	public Number getRowsPerStrip() {
-		return getNumberEntryValue(FieldTagType.RowsPerStrip);
+	public int getRowsPerStrip() {
+		return getNumberEntryValue(FieldTagType.RowsPerStrip).intValue();
 	}
 
 	/**
@@ -714,8 +714,8 @@ public class FileDirectory {
 	 * 
 	 * @return tile width
 	 */
-	public Number getTileWidth() {
-		return tiled ? getNumberEntryValue(FieldTagType.TileWidth)
+	public int getTileWidth() {
+		return tiled ? getNumberEntryValue(FieldTagType.TileWidth).intValue()
 				: getImageWidth();
 	}
 
@@ -744,8 +744,8 @@ public class FileDirectory {
 	 * 
 	 * @return tile height
 	 */
-	public Number getTileHeight() {
-		return tiled ? getNumberEntryValue(FieldTagType.TileLength)
+	public int getTileHeight() {
+		return tiled ? getNumberEntryValue(FieldTagType.TileLength).intValue()
 				: getRowsPerStrip();
 	}
 
@@ -1062,8 +1062,8 @@ public class FileDirectory {
 	public Rasters readRasters(ImageWindow window, int[] samples,
 			boolean sampleValues, boolean interleaveValues) {
 
-		int width = getImageWidth().intValue();
-		int height = getImageHeight().intValue();
+		int width = getImageWidth();
+		int height = getImageHeight();
 
 		// Validate the image window
 		if (window.getMinX() < 0 || window.getMinY() < 0
@@ -1130,16 +1130,13 @@ public class FileDirectory {
 	 */
 	private void readRaster(ImageWindow window, int[] samples, Rasters rasters) {
 
-		int tileWidth = getTileWidth().intValue();
-		int tileHeight = getTileHeight().intValue();
+		int tileWidth = getTileWidth();
+		int tileHeight = getTileHeight();
 
-		int minXTile = (int) Math
-				.floor(window.getMinX() / ((double) tileWidth));
-		int maxXTile = (int) Math.ceil(window.getMaxX() / ((double) tileWidth));
-		int minYTile = (int) Math.floor(window.getMinY()
-				/ ((double) tileHeight));
-		int maxYTile = (int) Math
-				.ceil(window.getMaxY() / ((double) tileHeight));
+		int minXTile = window.getMinX() / tileWidth;
+		int maxXTile = (window.getMaxX() + tileWidth - 1) / tileWidth;
+		int minYTile = window.getMinY() / tileHeight;
+		int maxYTile = (window.getMaxY() + tileHeight - 1) / tileHeight;
 
 		int windowWidth = window.getMaxX() - window.getMinX();
 
@@ -1338,10 +1335,10 @@ public class FileDirectory {
 
 		byte[] tileOrStrip = null;
 
-		int numTilesPerRow = (int) Math.ceil(getImageWidth().doubleValue()
-				/ getTileWidth().doubleValue());
-		int numTilesPerCol = (int) Math.ceil(getImageHeight().doubleValue()
-				/ getTileHeight().doubleValue());
+		int tileWidth = getTileWidth();
+		int tileHeight = getTileHeight();
+		int numTilesPerRow = (getImageWidth() + tileWidth - 1) / tileWidth;
+		int numTilesPerCol = (getImageHeight() + tileHeight - 1) / tileHeight;
 
 		int index = 0;
 		if (planarConfiguration == TiffConstants.PLANAR_CONFIGURATION_CHUNKY) {

--- a/src/main/java/mil/nga/tiff/ImageWindow.java
+++ b/src/main/java/mil/nga/tiff/ImageWindow.java
@@ -67,8 +67,8 @@ public class ImageWindow {
 	public ImageWindow(FileDirectory fileDirectory) {
 		this.minX = 0;
 		this.minY = 0;
-		this.maxX = fileDirectory.getImageWidth().intValue();
-		this.maxY = fileDirectory.getImageHeight().intValue();
+		this.maxX = fileDirectory.getImageWidth();
+		this.maxY = fileDirectory.getImageHeight();
 	}
 
 	/**

--- a/src/main/java/mil/nga/tiff/TiffWriter.java
+++ b/src/main/java/mil/nga/tiff/TiffWriter.java
@@ -174,7 +174,7 @@ public class TiffWriter {
 			List<Long> valueBytesCheck = new ArrayList<>();
 
 			// Write the raster bytes to temporary storage
-			if (fileDirectory.getRowsPerStrip() == null) {
+			if (fileDirectory.isTiled()) {
 				throw new TiffException("Tiled images are not supported");
 			}
 
@@ -259,7 +259,7 @@ public class TiffWriter {
 		}
 
 		// Populate the raster entries
-		if (fileDirectory.getRowsPerStrip() != null) {
+		if (!fileDirectory.isTiled()) {
 			populateStripEntries(fileDirectory);
 		} else {
 			throw new TiffException("Tiled images are not supported");
@@ -272,14 +272,12 @@ public class TiffWriter {
 	 * 
 	 * @param fileDirectory
 	 *            file directory
-	 * @param strips
-	 *            number of strips
 	 */
 	private static void populateStripEntries(FileDirectory fileDirectory) {
 
-		int rowsPerStrip = fileDirectory.getRowsPerStrip().intValue();
-		int stripsPerSample = (int) Math.ceil(fileDirectory.getImageHeight()
-				.doubleValue() / rowsPerStrip);
+		int rowsPerStrip = fileDirectory.getRowsPerStrip();
+		int stripsPerSample = (fileDirectory.getImageHeight() + rowsPerStrip - 1)
+				/ rowsPerStrip;
 		int strips = stripsPerSample;
 		if (fileDirectory.getPlanarConfiguration() == TiffConstants.PLANAR_CONFIGURATION_PLANAR) {
 			strips *= fileDirectory.getSamplesPerPixel();
@@ -327,7 +325,7 @@ public class TiffWriter {
 		ByteWriter writer = new ByteWriter(byteOrder);
 
 		// Write the rasters
-		if (fileDirectory.getRowsPerStrip() != null) {
+		if (!fileDirectory.isTiled()) {
 			writeStripRasters(writer, fileDirectory, offset, sampleFieldTypes,
 					encoder);
 		} else {
@@ -364,8 +362,8 @@ public class TiffWriter {
 		Rasters rasters = fileDirectory.getWriteRasters();
 
 		// Get the row and strip counts
-		int rowsPerStrip = fileDirectory.getRowsPerStrip().intValue();
-		int maxY = fileDirectory.getImageHeight().intValue();
+		int rowsPerStrip = fileDirectory.getRowsPerStrip();
+		int maxY = fileDirectory.getImageHeight();
 		int stripsPerSample = (int) Math.ceil((double) maxY
 				/ (double) rowsPerStrip);
 		int strips = stripsPerSample;
@@ -397,7 +395,7 @@ public class TiffWriter {
 
 				ByteWriter rowWriter = new ByteWriter(writer.getByteOrder());
 
-				for (int x = 0; x < fileDirectory.getImageWidth().intValue(); x++) {
+				for (int x = 0; x < fileDirectory.getImageWidth(); x++) {
 
 					if (sample != null) {
 						Number value = rasters.getPixelSample(sample, x, y);


### PR DESCRIPTION
This makes getImageWidth() etc. more handy. but breaks compatibility. also Math.floor() and Math.ceil() was replaced by integer arithmetic.