### PR TITLE
PKZIP_DEFLATE declared as deprecated

### DIFF
--- a/src/main/java/mil/nga/tiff/TiffWriter.java
+++ b/src/main/java/mil/nga/tiff/TiffWriter.java
@@ -457,6 +457,7 @@ public class TiffWriter {
 	 *            file directory
 	 * @return encoder
 	 */
+	@SuppressWarnings("deprecation")
 	private static CompressionEncoder getEncoder(FileDirectory fileDirectory) {
 
 		CompressionEncoder encoder = null;
@@ -466,6 +467,7 @@ public class TiffWriter {
 		if (compression == null) {
 			compression = TiffConstants.COMPRESSION_NO;
 		}
+
 		switch (compression) {
 		case TiffConstants.COMPRESSION_NO:
 			encoder = new RawCompression();
@@ -487,14 +489,12 @@ public class TiffWriter {
 			throw new TiffException("JPEG compression not supported: "
 					+ compression);
 		case TiffConstants.COMPRESSION_DEFLATE:
+		case TiffConstants.COMPRESSION_PKZIP_DEFLATE:
 			encoder = new DeflateCompression();
 			break;
 		case TiffConstants.COMPRESSION_PACKBITS:
 			encoder = new PackbitsCompression();
 			break;
-		case TiffConstants.COMPRESSION_PKZIP_DEFLATE:
-			throw new TiffException("PKZIP Deflate not supported for encoding. " +
-									"Use Adobe-style instead (COMPRESSION_DEFLATE)");
 		default:
 			throw new TiffException("Unknown compression method identifier: "
 					+ compression);

--- a/src/main/java/mil/nga/tiff/util/TiffConstants.java
+++ b/src/main/java/mil/nga/tiff/util/TiffConstants.java
@@ -56,6 +56,7 @@ public class TiffConstants {
 	public static final int COMPRESSION_JPEG_OLD = 6;
 	public static final int COMPRESSION_JPEG_NEW = 7;
 	public static final int COMPRESSION_DEFLATE = 8;
+	@Deprecated
 	public static final int COMPRESSION_PKZIP_DEFLATE = 32946; // PKZIP-style Deflate encoding (Obsolete).
 	public static final int COMPRESSION_PACKBITS = 32773;
 


### PR DESCRIPTION
Best should be for PKZIP_DEFLATE to be declared as deprecated and free to use instead firing an exception.