### PR TITLE
Used ByteBuffer instead of arrays in Rasters

### DIFF
--- a/src/main/java/mil/nga/tiff/FileDirectory.java
+++ b/src/main/java/mil/nga/tiff/FileDirectory.java
@@ -483,17 +483,12 @@ public class FileDirectory {
 	 * 
 	 * @return samples per pixel
 	 */
-	public Integer getSamplesPerPixel() {
+	public int getSamplesPerPixel() {
 		Integer samplesPerPixel = getIntegerEntryValue(FieldTagType.SamplesPerPixel);
 		if (samplesPerPixel == null) {
-			// if SamplesPerPixel tag is missing, try using length of
-			// BitsPerSample list
-			List<Integer> bitsPerSampleList = getBitsPerSample();
-			if (bitsPerSampleList != null) {
-				samplesPerPixel = bitsPerSampleList.size();
-			}
+			// if SamplesPerPixel tag is missing, use default value defined by TIFF standard
+			return 1;
 		}
-
 		return samplesPerPixel;
 	}
 

--- a/src/main/java/mil/nga/tiff/FileDirectory.java
+++ b/src/main/java/mil/nga/tiff/FileDirectory.java
@@ -1487,7 +1487,7 @@ public class FileDirectory {
 	 *
 	 * @param fieldTagType
 	 *            field tag type
-	 * @return number value
+	 * @return string value
 	 */
 	public String getStringEntryValue(FieldTagType fieldTagType) {
 		String value = null;
@@ -1502,7 +1502,9 @@ public class FileDirectory {
 	 * Set string value for the field tag type
 	 *
 	 * @param fieldTagType
+	 *            field tag type
 	 * @param value
+	 *            string value
 	 */
 	public void setStringEntryValue(FieldTagType fieldTagType, String value) {
 		List<String> values = new ArrayList<>();
@@ -1539,7 +1541,7 @@ public class FileDirectory {
 	 *            field tag type
 	 * @return max integer value
 	 */
-	private Integer getMaxIntegerEntryValue(FieldTagType fieldTagType) {
+	public Integer getMaxIntegerEntryValue(FieldTagType fieldTagType) {
 		Integer maxValue = null;
 		List<Integer> values = getIntegerListEntryValue(fieldTagType);
 		if (values != null) {
@@ -1555,7 +1557,7 @@ public class FileDirectory {
 	 *            field tag type
 	 * @return long list value
 	 */
-	private List<Number> getNumberListEntryValue(FieldTagType fieldTagType) {
+	public List<Number> getNumberListEntryValue(FieldTagType fieldTagType) {
 		return getEntryValue(fieldTagType);
 	}
 
@@ -1566,7 +1568,7 @@ public class FileDirectory {
 	 *            field tag type
 	 * @return long list value
 	 */
-	private List<Long> getLongListEntryValue(FieldTagType fieldTagType) {
+	public List<Long> getLongListEntryValue(FieldTagType fieldTagType) {
 		return getEntryValue(fieldTagType);
 	}
 
@@ -1576,7 +1578,7 @@ public class FileDirectory {
 	 * @param fieldTagType
 	 * @param value
 	 */
-	private void setUnsignedLongListEntryValue(FieldTagType fieldTagType,
+	public void setUnsignedLongListEntryValue(FieldTagType fieldTagType,
 			List<Long> value) {
 		setEntryValue(fieldTagType, FieldType.LONG, value.size(), value);
 	}

--- a/src/main/java/mil/nga/tiff/Rasters.java
+++ b/src/main/java/mil/nga/tiff/Rasters.java
@@ -5,7 +5,6 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sun.javafx.beans.annotations.NonNull;
 import mil.nga.tiff.util.TiffConstants;
 import mil.nga.tiff.util.TiffException;
 
@@ -758,7 +757,7 @@ public class Rasters {
 	 * @param fieldType Field type to be read
 	 * @return Sample form buffer
 	 */
-	private Number readSample(@NonNull ByteBuffer buffer, @NonNull FieldType fieldType) {
+	private Number readSample(ByteBuffer buffer, FieldType fieldType) {
 		Number sampleValue;
 
 		switch (fieldType) {
@@ -800,7 +799,7 @@ public class Rasters {
 	 * @param fieldType Field type to be written.
 	 * @param value Actual value to write.
 	 */
-	private void writeSample(@NonNull ByteBuffer buffer, @NonNull FieldType fieldType, @NonNull Number value) {
+	private void writeSample(ByteBuffer buffer, FieldType fieldType, Number value) {
 		switch (fieldType) {
 			case BYTE:
 			case SBYTE:
@@ -832,8 +831,8 @@ public class Rasters {
 	 * @param inBuffer A buffer to read from. @note Make sure buffer position is set.
 	 * @param fieldType Field type to be read.
 	 */
-	private void writeSample(@NonNull ByteBuffer outBuffer, @NonNull ByteBuffer inBuffer,
-							 @NonNull FieldType fieldType) {
+	private void writeSample(ByteBuffer outBuffer, ByteBuffer inBuffer,
+							 FieldType fieldType) {
 		switch (fieldType)
 		{
 			case BYTE:

--- a/src/main/java/mil/nga/tiff/Rasters.java
+++ b/src/main/java/mil/nga/tiff/Rasters.java
@@ -145,25 +145,6 @@ public class Rasters {
 	}
 
 	/**
-	 * Make a bits per sample list where each samples of a pixel has the same
-	 * value
-	 * 
-	 * @param samplesPerPixel
-	 *            samples per pixel
-	 * @param bitsPerSample
-	 *            bits per sample for all samples of a pixel
-	 * @return bits per sample list
-	 */
-	public static List<Integer> makeBitsPerSampleList(int samplesPerPixel,
-			int bitsPerSample) {
-		List<Integer> bitsPerSampleList = new ArrayList<Integer>();
-		for (int i = 0; i < samplesPerPixel; ++i) {
-			bitsPerSampleList.add(bitsPerSample);
-		}
-		return bitsPerSampleList;
-	}
-
-	/**
 	 * Constructor
 	 * 
 	 * @param width
@@ -611,4 +592,24 @@ public class Rasters {
 
 		return rowsPerStrip;
 	}
+
+	/**
+	 * Make a bits per sample list where each samples of a pixel has the same
+	 * value
+	 * 
+	 * @param samplesPerPixel
+	 *            samples per pixel
+	 * @param bitsPerSample
+	 *            bits per sample for all samples of a pixel
+	 * @return bits per sample list
+	 */
+	public static List<Integer> makeBitsPerSampleList(int samplesPerPixel,
+			int bitsPerSample) {
+		List<Integer> bitsPerSampleList = new ArrayList<Integer>();
+		for (int i = 0; i < samplesPerPixel; ++i) {
+			bitsPerSampleList.add(bitsPerSample);
+		}
+		return bitsPerSampleList;
+	}
+
 }

--- a/src/main/java/mil/nga/tiff/TiffWriter.java
+++ b/src/main/java/mil/nga/tiff/TiffWriter.java
@@ -3,6 +3,7 @@ package mil.nga.tiff;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -391,28 +392,14 @@ public class TiffWriter {
 
 			int endingY = Math.min(startingY + rowsPerStrip, maxY);
 			for (int y = startingY; y < endingY; y++) {
-
-				ByteWriter rowWriter = new ByteWriter(writer.getByteOrder());
-
-				for (int x = 0; x < fileDirectory.getImageWidth().intValue(); x++) {
-
-					if (sample != null) {
-						Number value = rasters.getPixelSample(sample, x, y);
-						FieldType fieldType = sampleFieldTypes[sample];
-						writeValue(rowWriter, fieldType, value);
-					} else {
-						Number[] values = rasters.getPixel(x, y);
-						for (int sampleIndex = 0; sampleIndex < values.length; sampleIndex++) {
-							Number value = values[sampleIndex];
-							FieldType fieldType = sampleFieldTypes[sampleIndex];
-							writeValue(rowWriter, fieldType, value);
-						}
-					}
-				}
-
 				// Get the row bytes and encode if needed
-				byte[] rowBytes = rowWriter.getBytes();
-				rowWriter.close();
+				byte[] rowBytes = null;
+				if (sample != null) {
+					rowBytes = rasters.getSampleRow(y, sample, writer.getByteOrder());
+				} else {
+					rowBytes = rasters.getPixelRow(y, writer.getByteOrder());
+				}
+			
 				if (encoder.rowEncoding()) {
 					rowBytes = encoder.encode(rowBytes, writer.getByteOrder());
 				}

--- a/src/main/java/mil/nga/tiff/TiffWriter.java
+++ b/src/main/java/mil/nga/tiff/TiffWriter.java
@@ -3,7 +3,6 @@ package mil.nga.tiff;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -312,11 +311,11 @@ public class TiffWriter {
 		}
 
 		// Get the sample field types
-		FieldType[] sampleFieldTypes = new FieldType[rasters
+		Rasters.SampleType[] sampleTypes = new Rasters.SampleType[rasters
 				.getSamplesPerPixel()];
 		for (int sample = 0; sample < rasters.getSamplesPerPixel(); sample++) {
-			sampleFieldTypes[sample] = fileDirectory
-					.getFieldTypeForSample(sample);
+			sampleTypes[sample] = fileDirectory
+					.getTypeForSample(sample);
 		}
 
 		// Get the compression encoder
@@ -327,7 +326,7 @@ public class TiffWriter {
 
 		// Write the rasters
 		if (!fileDirectory.isTiled()) {
-			writeStripRasters(writer, fileDirectory, offset, sampleFieldTypes,
+			writeStripRasters(writer, fileDirectory, offset, sampleTypes,
 					encoder);
 		} else {
 			throw new TiffException("Tiled images are not supported");
@@ -349,7 +348,7 @@ public class TiffWriter {
 	 *            file directory
 	 * @param offset
 	 *            byte offset
-	 * @param sampleFieldTypes
+	 * @param sampleTypes
 	 *            sample field types
 	 * @param encoder
 	 *            compression encoder
@@ -357,7 +356,7 @@ public class TiffWriter {
 	 */
 	private static void writeStripRasters(ByteWriter writer,
 			FileDirectory fileDirectory, long offset,
-			FieldType[] sampleFieldTypes, CompressionEncoder encoder)
+			Rasters.SampleType[] sampleTypes, CompressionEncoder encoder)
 			throws IOException {
 
 		Rasters rasters = fileDirectory.getWriteRasters();

--- a/src/test/java/mil/nga/tiff/TiffTestUtils.java
+++ b/src/test/java/mil/nga/tiff/TiffTestUtils.java
@@ -140,8 +140,8 @@ public class TiffTestUtils {
 				rasters2.getSampleValues().length);
 
 		for (int i = 0; i < rasters1.getSampleValues().length; i++) {
-			TestCase.assertEquals(rasters1.getSampleValues()[i].capacity() / rasters1.sizeSample(i),
-					rasters2.getSampleValues()[i].capacity()  / rasters2.sizeSample(i));
+			TestCase.assertEquals(rasters1.getSampleValues()[i].capacity() / rasters1.getSampleTypes()[i].byteSize,
+					rasters2.getSampleValues()[i].capacity()  / rasters2.getSampleTypes()[i].byteSize);
 
 			for (int x = 0; x < rasters1.getWidth(); ++x) {
 				for (int y = 0; y < rasters1.getHeight(); ++y) {

--- a/src/test/java/mil/nga/tiff/TiffTestUtils.java
+++ b/src/test/java/mil/nga/tiff/TiffTestUtils.java
@@ -94,7 +94,7 @@ public class TiffTestUtils {
 		TestCase.assertEquals(fileDirectory.getImageWidth(), rasters.getWidth());
 		TestCase.assertEquals(fileDirectory.getImageHeight(),
 				rasters.getHeight());
-		TestCase.assertEquals(fileDirectory.getSamplesPerPixel().intValue(),
+		TestCase.assertEquals(fileDirectory.getSamplesPerPixel(),
 				rasters.getSamplesPerPixel());
 		TestCase.assertEquals(fileDirectory.getBitsPerSample().size(), rasters
 				.getBitsPerSample().size());

--- a/src/test/java/mil/nga/tiff/TiffTestUtils.java
+++ b/src/test/java/mil/nga/tiff/TiffTestUtils.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import junit.framework.TestCase;
 import mil.nga.tiff.util.TiffException;
@@ -139,11 +140,13 @@ public class TiffTestUtils {
 				rasters2.getSampleValues().length);
 
 		for (int i = 0; i < rasters1.getSampleValues().length; i++) {
-			TestCase.assertEquals(rasters1.getSampleValues()[i].length,
-					rasters2.getSampleValues()[i].length);
-			for (int j = 0; j < rasters2.getSampleValues()[i].length; j++) {
-				compareNumbers(rasters1.getSampleValues()[i][j],
-						rasters2.getSampleValues()[i][j], exactType);
+			TestCase.assertEquals(rasters1.getSampleValues()[i].capacity() / rasters1.sizeSample(i),
+					rasters2.getSampleValues()[i].capacity()  / rasters2.sizeSample(i));
+
+			for (int x = 0; x < rasters1.getWidth(); ++x) {
+				for (int y = 0; y < rasters1.getHeight(); ++y) {
+					compareNumbers(rasters1.getPixelSample(i, x, y), rasters2.getPixelSample(i, x, y), exactType);
+				}
 			}
 		}
 	}
@@ -180,12 +183,16 @@ public class TiffTestUtils {
 
 		TestCase.assertNotNull(rasters1.getInterleaveValues());
 		TestCase.assertNotNull(rasters2.getInterleaveValues());
-		TestCase.assertEquals(rasters1.getInterleaveValues().length,
-				rasters2.getInterleaveValues().length);
+		TestCase.assertEquals(rasters1.getInterleaveValues().capacity() / rasters1.sizePixel(),
+				rasters2.getInterleaveValues().capacity() / rasters2.sizePixel());
 
-		for (int i = 0; i < rasters1.getInterleaveValues().length; i++) {
-			compareNumbers(rasters1.getInterleaveValues()[i],
-					rasters2.getInterleaveValues()[i], exactType);
+
+		for (int i = 0; i < rasters1.getSamplesPerPixel(); i++) {
+			for (int x = 0; x < rasters1.getWidth(); ++x) {
+				for (int y = 0; y < rasters1.getHeight(); ++y) {
+					compareNumbers(rasters1.getPixelSample(i, x, y), rasters2.getPixelSample(i, x, y), exactType);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Used ByteBuffer instead of arrays in Raster objects to avoid usage of arrays and multidimensional arrays. This will allow us more optimized use of memory and possibility to use library in low-memory environment.